### PR TITLE
Initial DRM Implementation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    gdb git meson cmake ninja-build pkg-config nano clang clang-format clang-tidy clang-tools \
+    libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev fonts-liberation fontconfig libsystemd-dev libinput-dev libudev-dev libxkbcommon-dev libseat-dev \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-alsa \
+    libcurl4-openssl-dev \
+    hwdata

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "./Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Configure tool-specific properties.
+	// "customizations": {},
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"editor.formatOnSave": true,
+				"files.insertFinalNewline": true
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"github.vscode-github-actions",
+				"ms-azuretools.vscode-docker",
+				"mesonbuild.mesonbuild"
+			]
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -3,6 +3,8 @@ name: clang-format
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+  push:
+    branches: [ "dev" ]
 
 jobs:
   format:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -3,7 +3,9 @@ name: clang-tidy
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
-
+  push:
+    branches: [ "dev" ]
+    
 jobs:
   tidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         pip install --user meson
         sudo apt-get -y install ninja-build \
-        libdrm-dev libinput-dev libsystemd-dev libxkbcommon-dev
+        libdrm-dev libgbm-dev libinput-dev libsystemd-dev libxkbcommon-dev
         meson --version
         gcc --version
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode
 buildDir
+.zed
 
 subprojects/edid-decode.wrap
 subprojects/edid-decode

--- a/examples/drm_cursor.cc
+++ b/examples/drm_cursor.cc
@@ -140,28 +140,28 @@ class App final : public drmpp::input::KeyboardObserver,
   }
 
   void notify_pointer_motion(drmpp::input::Pointer *pointer,
-                             uint32_t time,
-                             double sx,
-                             double sy) override {
+                             const uint32_t time,
+                             const double sx,
+                             const double sy) override {
     LOG_TRACE("dx: {}, dy: {}", sx, sy);
     pointer_x_ = std::clamp(pointer_x_ + sx, 0.0, static_cast<double>(width_));
     pointer_y_ = std::clamp(pointer_y_ + sy, 0.0, static_cast<double>(height_));
   }
 
   void notify_pointer_motion_absolute(drmpp::input::Pointer *pointer,
-                                      uint32_t time,
-                                      double ndc_x,
-                                      double ndc_y) override {
+                                      const uint32_t time,
+                                      const double ndc_x,
+                                      const double ndc_y) override {
     pointer_x_ = static_cast<double>(width_) * ndc_x;
     pointer_y_ = static_cast<double>(height_) * ndc_y;
     LOG_DEBUG("x: {}, y: {}", pointer_x_, pointer_y_);
   }
 
   void notify_pointer_button(drmpp::input::Pointer *pointer,
-                             uint32_t serial,
-                             uint32_t time,
-                             uint32_t button,
-                             uint32_t state) override {
+                             const uint32_t serial,
+                             const uint32_t time,
+                             const uint32_t button,
+                             const uint32_t state) override {
     LOG_INFO("button: {}, state: {}", button, state);
   }
 

--- a/examples/drm_cursor.cc
+++ b/examples/drm_cursor.cc
@@ -115,6 +115,13 @@ public:
     LOG_TRACE("x: {}, y: {}", sx, sy);
   }
 
+  void notify_pointer_motion_absolute(drmpp::input::Pointer *pointer,
+                                      uint32_t time,
+                                      double ndc_x,
+                                      double ndc_y) override {
+    LOG_TRACE("ndc x: {}, ndc y: {}", ndc_x, ndc_y);
+  }
+
   void notify_pointer_button(drmpp::input::Pointer *pointer,
                              uint32_t serial,
                              uint32_t time,

--- a/examples/drm_cursor.cc
+++ b/examples/drm_cursor.cc
@@ -19,15 +19,16 @@
 #include <fstream>
 #include <iostream>
 
-#include <cxxopts.hpp>
 #include <utils/virtual_terminal.h>
+#include <cxxopts.hpp>
 
 #include "drmpp.h"
+#include "input/default_left_ptr.h"
 #include "shared_libs/libdrm.h"
 #include "shared_libs/libgbm.h"
+#include "utils/utils.h"
 
-struct Configuration {
-};
+struct Configuration {};
 
 static volatile bool gRunning = true;
 
@@ -51,18 +52,48 @@ void handle_signal(const int signal) {
 class App final : public drmpp::input::KeyboardObserver,
                   public drmpp::input::PointerObserver,
                   public drmpp::input::SeatObserver {
-public:
-  explicit App(const Configuration & /*config */)
-    : logging_(std::make_unique<Logging>()) {
+ public:
+  explicit App(const Configuration& /*config */)
+      : logging_(std::make_unique<Logging>()),
+        width_(0),
+        height_(0),
+        pointer_x_(0.0),
+        pointer_y_(0.0) {
     seat_ = std::make_unique<drmpp::input::Seat>(false, "");
     seat_->register_observer(this, this);
   }
 
   ~App() override { seat_.reset(); }
 
-  [[nodiscard]] bool run() const { return seat_->run_once(); }
+  [[nodiscard]] bool run() {
+    using namespace drmpp;
 
-  void notify_seat_capabilities(drmpp::input::Seat *seat,
+    if (!ensureInitialized()) {
+      return false;
+    }
+
+    seat_->run_once();
+
+    Composition composition;
+    composition.addLayer({
+        fb_,
+        {0, 0, width_, height_},
+        {0, 0, width_, height_},
+    });
+
+    composition.addPointerLayer({
+        .buffer = cursor_->buffer,
+        .hot_x = cursor_->hot_x,
+        .hot_y = cursor_->hot_y,
+        .x = static_cast<uint32_t>(std::round(pointer_x_)),
+        .y = static_cast<uint32_t>(std::round(pointer_y_)),
+    });
+
+    output_->present(composition);
+    return true;
+  }
+
+  void notify_seat_capabilities(drmpp::input::Seat* seat,
                                 uint32_t caps) override {
     LOG_INFO("Seat Capabilities: {}", caps);
     if (caps & SEAT_CAPABILITIES_POINTER) {
@@ -72,8 +103,8 @@ public:
     }
     if (caps & SEAT_CAPABILITIES_KEYBOARD) {
       if (const auto keyboards = seat_->get_keyboards();
-        keyboards.has_value()) {
-        for (auto const &keyboard: *keyboards.value()) {
+          keyboards.has_value()) {
+        for (auto const& keyboard : *keyboards.value()) {
           keyboard->register_observer(this, this);
         }
       }
@@ -81,13 +112,13 @@ public:
   }
 
   void notify_keyboard_xkb_v1_key(
-    drmpp::input::Keyboard *keyboard,
-    uint32_t time,
-    uint32_t xkb_scancode,
-    bool keymap_key_repeats,
-    const uint32_t state,
-    int xdg_key_symbol_count,
-    const xkb_keysym_t *xdg_key_symbols) override {
+      drmpp::input::Keyboard* keyboard,
+      uint32_t time,
+      uint32_t xkb_scancode,
+      bool keymap_key_repeats,
+      const uint32_t state,
+      int xdg_key_symbol_count,
+      const xkb_keysym_t* xdg_key_symbols) override {
     if (state == LIBINPUT_KEY_STATE_PRESSED) {
       if (xdg_key_symbols[0] == XKB_KEY_Escape ||
           xdg_key_symbols[0] == XKB_KEY_q || xdg_key_symbols[0] == XKB_KEY_Q) {
@@ -101,25 +132,29 @@ public:
       }
     }
     LOG_INFO(
-      "Key: time: {}, xkb_scancode: 0x{:X}, key_repeats: {}, state: {}, "
-      "xdg_keysym_count: {}, syms_out[0]: 0x{:X}",
-      time, xkb_scancode, keymap_key_repeats,
-      state == LIBINPUT_KEY_STATE_PRESSED ? "press" : "release",
-      xdg_key_symbol_count, xdg_key_symbols[0]);
+        "Key: time: {}, xkb_scancode: 0x{:X}, key_repeats: {}, state: {}, "
+        "xdg_keysym_count: {}, syms_out[0]: 0x{:X}",
+        time, xkb_scancode, keymap_key_repeats,
+        state == LIBINPUT_KEY_STATE_PRESSED ? "press" : "release",
+        xdg_key_symbol_count, xdg_key_symbols[0]);
   }
 
   void notify_pointer_motion(drmpp::input::Pointer *pointer,
                              uint32_t time,
                              double sx,
                              double sy) override {
-    LOG_TRACE("x: {}, y: {}", sx, sy);
+    LOG_TRACE("dx: {}, dy: {}", sx, sy);
+    pointer_x_ = std::clamp(pointer_x_ + sx, 0.0, static_cast<double>(width_));
+    pointer_y_ = std::clamp(pointer_y_ + sy, 0.0, static_cast<double>(height_));
   }
 
   void notify_pointer_motion_absolute(drmpp::input::Pointer *pointer,
                                       uint32_t time,
                                       double ndc_x,
                                       double ndc_y) override {
-    LOG_TRACE("ndc x: {}, ndc y: {}", ndc_x, ndc_y);
+    pointer_x_ = static_cast<double>(width_) * ndc_x;
+    pointer_y_ = static_cast<double>(height_) * ndc_y;
+    LOG_DEBUG("x: {}, y: {}", pointer_x_, pointer_y_);
   }
 
   void notify_pointer_button(drmpp::input::Pointer *pointer,
@@ -130,41 +165,190 @@ public:
     LOG_INFO("button: {}, state: {}", button, state);
   }
 
-  void notify_pointer_axis(drmpp::input::Pointer *pointer,
+  void notify_pointer_axis(drmpp::input::Pointer* pointer,
                            uint32_t time,
                            uint32_t axis,
                            double value) override {
     LOG_INFO("axis: {}", axis);
   }
 
-  void notify_pointer_frame(drmpp::input::Pointer *pointer) override {
+  void notify_pointer_frame(drmpp::input::Pointer* pointer) override {
     LOG_INFO("frame");
   }
 
-  void notify_pointer_axis_source(drmpp::input::Pointer *pointer,
+  void notify_pointer_axis_source(drmpp::input::Pointer* pointer,
                                   uint32_t axis_source) override {
     LOG_INFO("axis_source: {}", axis_source);
   }
 
-  void notify_pointer_axis_stop(drmpp::input::Pointer *pointer,
+  void notify_pointer_axis_stop(drmpp::input::Pointer* pointer,
                                 uint32_t time,
                                 uint32_t axis) override {
     LOG_INFO("axis_stop: {}", axis);
   }
 
-  void notify_pointer_axis_discrete(drmpp::input::Pointer *pointer,
+  void notify_pointer_axis_discrete(drmpp::input::Pointer* pointer,
                                     uint32_t axis,
                                     int32_t discrete) override {
     LOG_INFO("axis_discrete: axis: {}, discrete: {}", axis, discrete);
   }
 
-private:
+ private:
+  struct LoadedCursor {
+    std::shared_ptr<drmpp::Buffer> buffer;
+    uint32_t hot_x, hot_y;
+  };
+
   std::unique_ptr<Logging> logging_;
   std::unique_ptr<drmpp::input::Seat> seat_;
   std::mutex cmd_mutex_{};
+
+  std::unique_ptr<drmpp::Device> device_;
+  std::unique_ptr<drmpp::Output> output_;
+  std::shared_ptr<drmpp::Buffer> fb_;
+  std::optional<LoadedCursor> cursor_;
+
+  std::uint32_t width_, height_;
+  double pointer_x_, pointer_y_;
+
+  static std::unique_ptr<drmpp::Device> openDevice() {
+    for (const auto& node : drmpp::utils::get_enabled_drm_nodes()) {
+      return drmpp::Device::open(node);
+    }
+
+    return nullptr;
+  }
+
+  static std::optional<LoadedCursor> loadCursor(drmpp::Device& device) {
+    // TODO: Move this somewhere so it's usable by everyone.
+    const auto cursor_bytes = CursorLeftPtr.decompress();
+
+    const auto cursor = drmpp::XCursor::load_images(cursor_bytes, 24);
+    if (!cursor) {
+      LOG_ERROR("Could not load default cursor file.");
+      return {};
+    }
+
+    if (cursor->images.empty()) {
+      LOG_ERROR("Default cursor has no valid cursor images.");
+      return {};
+    }
+
+    const auto* image = cursor->images.front().get();
+
+    uint32_t width = image->width;
+    uint32_t height = image->height;
+
+    // Drivers are sometimes picky with their cursor size.
+    // The KMS driver present in QEMU accepts any cursor size,
+    // but will only actually show the cursor on screen when
+    // it matches the desired size (64x64).
+    if (const auto desired = device.desiredCursorSize()) {
+      width = desired->first;
+      height = desired->second;
+    }
+
+    auto fb = device.createDumbBuffer(width, height, 32, DRM_FORMAT_ARGB8888,
+                                      device.supportsModifiers()
+                                          ? DRM_FORMAT_MOD_LINEAR
+                                          : DRM_FORMAT_MOD_INVALID);
+    if (!fb) {
+      return {};
+    }
+
+    uint32_t offset;
+    uint32_t stride;
+    std::size_t size;
+
+    void* mapped = fb->map(offset, stride, size);
+
+    // If the layout of the created framebuffer perfectly matches the
+    // layout of the X11 cursor image, we can just copy over the whole thing.
+    if (stride == image->width * 4 && size - offset == stride * image->height) {
+      std::memcpy(static_cast<uint8_t*>(mapped) + offset, image->pixels.data(),
+                  image->pixels.size() * 4);
+    } else {
+      // otherwise, we copy line-by-line.
+      for (uint32_t y = 0; y < image->height; y++) {
+        const auto dst_offset = offset + y * stride;
+        const auto src_stride = image->width * 4;
+        const auto src_offset = y * src_stride;
+
+        // Just some paranoid check that we don't write/read out of bounds.
+        assert(dst_offset + src_stride <= size - offset);
+        assert(src_offset + src_stride <= image->pixels.size() * 4);
+
+        std::memcpy(
+            static_cast<uint8_t*>(mapped) + dst_offset,
+            reinterpret_cast<const uint8_t*>(image->pixels.data()) + src_offset,
+            src_stride);
+      }
+    }
+
+    fb->unmap(mapped);
+
+    return LoadedCursor{
+        .buffer = std::move(fb),
+        .hot_x = image->xhot,
+        .hot_y = image->yhot,
+    };
+  }
+
+  bool ensureInitialized() {
+    if (device_) {
+      // Either all should be initialized, or none.
+      assert(output_ && fb_ && cursor_);
+      return true;
+    }
+
+    assert(!device_ && !output_ && !fb_ && !cursor_);
+
+    device_ = openDevice();
+    if (!device_) {
+      return false;
+    }
+
+    output_ = device_->openFirstConnectedOutput();
+    if (!output_) {
+      device_.reset();
+      return false;
+    }
+
+    LOG_INFO("Using connector {}, CRTC {}", output_->connector_id(),
+             output_->crtc_id());
+
+    const auto mode = output_->mode();
+    LOG_INFO("Mode: {}x{}@{}Hz", mode.hdisplay, mode.vdisplay,
+             output_->refreshRate());
+
+    width_ = mode.hdisplay;
+    height_ = mode.vdisplay;
+
+    fb_ = device_->createDumbBuffer(width_, height_, 32, DRM_FORMAT_XRGB8888,
+                                    device_->supportsModifiers()
+                                        ? DRM_FORMAT_MOD_LINEAR
+                                        : DRM_FORMAT_MOD_INVALID);
+    if (!fb_) {
+      output_.reset();
+      device_.reset();
+      return false;
+    }
+
+    fb_->fill(0xFFFFFFFF);
+
+    auto loaded = loadCursor(*device_);
+    if (!loaded) {
+      output_.reset();
+      device_.reset();
+      return false;
+    }
+
+    cursor_ = std::move(loaded);
+    return true;
+  }
 };
 
-int main(const int argc, char **argv) {
+int main(const int argc, char** argv) {
   std::signal(SIGINT, handle_signal);
 
   cxxopts::Options options("drm-cursor", "Render Cursor");
@@ -178,7 +362,7 @@ int main(const int argc, char **argv) {
     exit(EXIT_SUCCESS);
   }
 
-  const App app({});
+  App app({});
 
   while (gRunning && app.run()) {
   }

--- a/include/drmpp/buffer.h
+++ b/include/drmpp/buffer.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024 drmpp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_DRMPP_BUFFER_H_
+#define INCLUDE_DRMPP_BUFFER_H_
+
+#include <gbm.h>
+#include <bitset>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace drmpp {
+
+class Buffer {
+ public:
+  struct Plane {
+    uint32_t gem_handle;
+    uint32_t offset;
+    uint32_t stride;
+    uint64_t size;
+  };
+
+  explicit Buffer(uint32_t width,
+                  uint32_t height,
+                  uint32_t format,
+                  uint64_t modifier,
+                  const Plane& plane)
+      : width_(width),
+        height_(height),
+        format_(format),
+        modifier_(modifier),
+        planes_({plane}) {}
+
+  explicit Buffer(uint32_t width,
+                  uint32_t height,
+                  uint32_t format,
+                  uint64_t modifier,
+                  std::initializer_list<Plane> planes)
+      : width_(width),
+        height_(height),
+        format_(format),
+        modifier_(modifier),
+        planes_(planes) {}
+
+  virtual ~Buffer() = default;
+
+  // Disallow copy, copy-assign, move, move-assign
+  Buffer(const Buffer&) = delete;
+  Buffer& operator=(const Buffer&) = delete;
+  Buffer(Buffer&&) = delete;
+  Buffer& operator=(Buffer&&) = delete;
+
+  [[nodiscard]] uint32_t width() const { return width_; }
+  [[nodiscard]] uint32_t height() const { return height_; }
+  [[nodiscard]] uint32_t format() const { return format_; }
+
+  /**
+   * @brief The format modifier (e.g. DRM_FORMAT_MOD_LINEAR) of the buffer.
+   *
+   * If the modifier is DRM_FORMAT_MOD_INVALID, the buffer could be linear.
+   * Especially dumb buffers will almost certainly be linear. For GBM buffers,
+   * the actual memory layout is undefined in that case. It could be linear,
+   * but it could also be something driver-specific.
+   *
+   * @return The format modifier of the buffer.
+   */
+  [[nodiscard]] uint64_t modifier() const { return modifier_; }
+
+  [[nodiscard]] std::size_t n_planes() const { return planes_.size(); }
+
+  // Plane iterator
+  using const_iterator = std::vector<Plane>::const_iterator;
+  [[nodiscard]] const_iterator begin() const { return planes_.begin(); }
+  [[nodiscard]] const_iterator end() const { return planes_.end(); }
+
+  /**
+   * @brief Map the buffer for read/write CPU access.
+   *
+   * The buffer is always mapped linearly, regardless of the actual layout of
+   * the buffer in memory.
+   *
+   * @param offset The offset of the mapped memory.
+   * @param stride The stride of the mapped memory.
+   * @param size The size of the mapped memory.
+   * @param plane_index The index of the plane to map.
+   */
+  [[nodiscard]] virtual void* map(uint32_t& offset,
+                                  uint32_t& stride,
+                                  std::size_t& size,
+                                  std::size_t plane_index) = 0;
+
+  [[nodiscard]] void* map(uint32_t& offset,
+                          uint32_t& stride,
+                          std::size_t& size) {
+    return map(offset, stride, size, 0);
+  }
+
+  virtual void unmap(void* memory) = 0;
+
+  virtual void fill(uint32_t fourByteColor);
+
+ protected:
+  /**
+   * @brief Constructor that doesn't initialize the planes_ vector.
+   */
+  explicit Buffer(uint32_t width,
+                  uint32_t height,
+                  uint32_t format,
+                  uint64_t modifier)
+      : width_(width), height_(height), format_(format), modifier_(modifier) {}
+
+  const uint32_t width_;
+  const uint32_t height_;
+  const uint32_t format_;
+  const uint64_t modifier_;
+  std::vector<Plane> planes_;
+};
+
+class Framebuffer : public Buffer {
+ public:
+  explicit Framebuffer(Buffer& buffer, uint32_t fb_id)
+      : Buffer(buffer.width(),
+               buffer.height(),
+               buffer.format(),
+               buffer.modifier()),
+        inner_(buffer),
+        fb_id_(fb_id) {
+    planes_.reserve(buffer.n_planes());
+    for (const auto& plane : buffer) {
+      planes_.push_back(plane);
+    }
+  }
+
+  [[nodiscard]] inline uint32_t fb_id() const { return fb_id_; }
+
+  [[nodiscard]] void* map(uint32_t& offset,
+                          uint32_t& stride,
+                          std::size_t& size,
+                          std::size_t plane_index) override {
+    return inner_.map(offset, stride, size, plane_index);
+  }
+
+  void unmap(void* memory) override { inner_.unmap(memory); }
+
+ private:
+  Buffer& inner_;
+  const uint32_t fb_id_;
+};
+
+}  // namespace drmpp::drm
+
+#endif  // INCLUDE_DRMPP_BUFFER_H_

--- a/include/drmpp/composition.h
+++ b/include/drmpp/composition.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 drmpp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_DRMPP_COMPOSITION_H_
+#define INCLUDE_DRMPP_COMPOSITION_H_
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include "buffer.h"
+
+namespace drmpp {
+
+struct Rect {
+  uint32_t x;
+  uint32_t y;
+  uint32_t w;
+  uint32_t h;
+};
+
+class Composition final {
+ public:
+  struct Layer {
+    std::shared_ptr<Buffer> buffer;
+    Rect src = {0, 0, 0, 0};
+    Rect dst = {0, 0, 0, 0};
+  };
+
+  struct PointerLayer {
+    std::shared_ptr<Buffer> buffer;
+    uint32_t hot_x, hot_y;
+    uint32_t x, y;
+  };
+
+  Composition() = default;
+  ~Composition() = default;
+
+  // Allow move, move-assign
+  Composition(Composition&&) = default;
+  Composition& operator=(Composition&&) = default;
+
+  // Disallow copy and assign.
+  Composition(const Composition&) = delete;
+  Composition& operator=(const Composition&) = delete;
+
+  /**
+   * @brief Add a visible layer to the composition.
+   *
+   * More recently added layers will be rendered on top of older layers.
+   */
+  void addLayer(const Layer& layer) { layers_.push_back(layer); }
+
+  /**
+   * @brief Add a pointer layer to the composition, consisting of a pointer
+   * image and a position. Only one pointer layer can be added to a composition.
+   *
+   * Adding a second pointer layer is considered an API usage error and might
+   * result in an assertion failure.
+   *
+   * Presenting a Composition without a pointer layer will disable the pointer
+   * on that output. (In other words, a pointer layer needs to be added to every
+   * Composition that should display a pointer on screen.)
+   *
+   * TODO: Support out-of-band, higher-frequency updates via drmModeMoveCursor.
+   */
+  void addPointerLayer(const PointerLayer& layer) {
+    assert(!pointer_.has_value());
+    pointer_ = layer;
+  }
+  [[nodiscard]] const PointerLayer* pointerLayer() const {
+    return pointer_.has_value() ? &pointer_.value() : nullptr;
+  }
+
+  // Layer iterator
+  using const_iterator = std::vector<Layer>::const_iterator;
+  [[nodiscard]] const_iterator begin() const { return layers_.begin(); }
+  [[nodiscard]] const_iterator end() const { return layers_.end(); }
+
+ private:
+  std::optional<PointerLayer> pointer_;
+  std::vector<Layer> layers_;
+};
+
+}  // namespace drmpp
+
+#endif  // INCLUDE_DRMPP_COMPOSITION_H_

--- a/include/drmpp/device.h
+++ b/include/drmpp/device.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 drmpp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_DRMPP_DRM_DEVICE_H_
+#define INCLUDE_DRMPP_DRM_DEVICE_H_
+
+#include <fcntl.h>
+
+#include <optional>
+#include <string>
+
+#include <drm_fourcc.h>
+extern "C" {
+#include <libliftoff.h>
+}
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include "buffer.h"
+
+namespace drmpp {
+
+class Output;
+
+class Device {
+ public:
+  explicit Device(int fd, struct gbm_device* gbm_device)
+      : fd_(fd),
+        gbm_device_(gbm_device, gbm_device_destroy),
+        liftoff_device_(liftoff_device_create(fd), liftoff_device_destroy) {
+    liftoff_device_register_all_planes(liftoff_device_.get());
+
+    supportsModifiers_ = try_get_cap(DRM_CAP_ADDFB2_MODIFIERS).value_or(0) != 0;
+
+    const auto cursor_width = try_get_cap(DRM_CAP_CURSOR_WIDTH);
+    const auto cursor_height = try_get_cap(DRM_CAP_CURSOR_HEIGHT);
+    if (cursor_width && cursor_height) {
+      cursor_size_ = {cursor_width.value(), cursor_height.value()};
+    }
+  }
+
+  virtual ~Device();
+
+  // Disallow copy, copy-assign, move, move-assign
+  Device(const Device&) = delete;
+  Device& operator=(const Device&) = delete;
+  Device(Device&&) = delete;
+  Device& operator=(Device&&) = delete;
+
+  // The fd can be used to change internal state of this device,
+  // so we only provide non-const access.
+  // NOLINTNEXTLINE(readability-make-member-function-const)
+  [[nodiscard]] int fd() { return fd_; }
+  struct gbm_device* gbm_device() { return gbm_device_.get(); }
+  struct liftoff_device* liftoff_device() { return liftoff_device_.get(); }
+
+  [[nodiscard]] bool supportsModifiers() const { return supportsModifiers_; }
+
+  [[nodiscard]] std::optional<std::pair<uint32_t, uint32_t>> desiredCursorSize()
+      const {
+    return cursor_size_;
+  }
+
+  /**
+   * @brief Create a DRM buffer object using DRM_IOCTL_MODE_CREATE_DUMB.
+   *
+   * DRM_IOCTL_MODE_CREATE_DUMB can only be called on a modesetting node
+   * (/dev/dri/cardX) and the created buffer can only be used with the specific
+   * node it was created on.
+   *
+   * It's not supposed to be used for rendering (although sometimes, this may
+   * work), and sometimes even writing to it is not straightforward. It is
+   * guaranteed however that scanning it out will work.
+   *
+   * @param width The width of the buffer.
+   * @param height The height of the buffer.
+   * @param bpp The bits per pixel of the buffer.
+   * @param format The format of the buffer. (Used when later adding it as a
+   * framebuffer)
+   * @param modifier The modifier of the buffer. This is used to initialize
+   *                 the modifier() field of the buffer.
+   *                 If DRM_FORMAT_MOD_LINEAR is specified here, registering
+   *                 the buffer as a framebuffer might fail if the driver
+   *                 doesn't support modifiers.
+   */
+  std::unique_ptr<Buffer> createDumbBuffer(
+      uint32_t width,
+      uint32_t height,
+      uint32_t bpp,
+      uint32_t format,
+      uint64_t modifier = DRM_FORMAT_MOD_INVALID);
+
+  /**
+   * @brief Create a DRM buffer object using GBM.
+   *
+   * Internally delegates to gbm_bo_create_with_modifiers2,
+   * gbm_bo_create_with_modifiers and gbm_bo_create.
+   *
+   * GBM BO creation has a bit of format negotation built in. If given
+   * a list of modifiers, it will try to select one that works with the
+   * the given format & usage flags.
+   *
+   * @param width The width of the buffer.
+   * @param height The height of the buffer.
+   * @param format The format of the buffer. (Used when later adding it as a
+   * framebuffer)
+   * @param allowed_modifiers A list of allowed modifiers for the buffer.
+   *                          If empty, explicit modifiers won't be used.
+   * @param usage The usage flags for the buffer.
+   */
+  std::unique_ptr<Buffer> createGbmBuffer(
+      uint32_t width,
+      uint32_t height,
+      uint32_t format,
+      const std::vector<uint64_t>& allowed_modifiers,
+      uint32_t usage);
+
+  /**
+   * @brief Register a raw buffer object as a framebuffer to the KMS device,
+   *        which will give it a framebuffer ID.
+   *
+   * @param buffer The raw buffer to create the framebuffer from.
+   * @returns A unique pointer to the created framebuffer.
+   */
+  std::unique_ptr<Framebuffer> addFramebuffer(Buffer& buffer);
+
+  /**
+   * @brief Create a DrmOutput of the first connected
+   *        connector & CRTC of the device.
+   */
+  std::unique_ptr<Output> openFirstConnectedOutput();
+
+  static std::unique_ptr<Device> create(int drm_fd) {
+    auto gbm_device = gbm_create_device(drm_fd);
+    if (!gbm_device) {
+      return nullptr;
+    }
+
+    int ok = drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+    if (ok < 0) {
+      return nullptr;
+    }
+
+    return std::make_unique<Device>(drm_fd, gbm_device);
+  }
+
+  static std::unique_ptr<Device> open(const std::string& path) {
+    auto fd = ::open(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+      return nullptr;
+    }
+
+    return create(fd);
+  }
+
+ private:
+  const int fd_;
+
+  bool supportsModifiers_;
+  std::optional<std::pair<uint32_t, uint32_t>> cursor_size_;
+
+  std::unique_ptr<struct gbm_device, decltype(&::gbm_device_destroy)>
+      gbm_device_;
+
+  std::unique_ptr<struct liftoff_device, decltype(&::liftoff_device_destroy)>
+      liftoff_device_;
+
+  [[nodiscard]] std::optional<uint64_t> try_get_cap(uint64_t cap) const;
+};
+
+}  // namespace drmpp
+
+#endif  // INCLUDE_DRMPP_DEVICE_H_

--- a/include/drmpp/input/asset.h
+++ b/include/drmpp/input/asset.h
@@ -18,12 +18,30 @@
 #define INCLUDE_DRMPP_INPUT_ASSET_H
 
 #include <cstdint>
+#include <vector>
+
+#include "fastlz.h"
 
 template <size_t CompressedSize, size_t UncompressedSize>
 struct Asset {
   size_t compressed_size = CompressedSize;
   size_t uncompressed_size = UncompressedSize;
   uint8_t data[CompressedSize];
+
+  std::vector<uint8_t> decompress() const {
+    std::vector<uint8_t> v;
+
+    v.resize(uncompressed_size);
+
+    int result = ::fastlz_decompress(data, compressed_size, v.data(), v.size());
+    if (result == 0) {
+      return {};
+    } else if (static_cast<size_t>(result) != uncompressed_size) {
+      return {};
+    }
+
+    return v;
+  }
 };
 
 #endif  // INCLUDE_DRMPP_INPUT_ASSET_H

--- a/include/drmpp/input/pointer.h
+++ b/include/drmpp/input/pointer.h
@@ -39,18 +39,32 @@ namespace drmpp::input {
     virtual ~PointerObserver() = default;
 
     /**
-     * \brief Notify the observer of a pointer motion event.
+     * \brief Notify the observer of a relative pointer motion event.
      *
      * \param pointer Pointer to the Pointer instance.
      * \param time The time of the event.
-     * \param sx The x-coordinate of the pointer.
-     * \param sy The y-coordinate of the pointer.
+     * \param sx The delta of the x-coordinate of the pointer.
+     * \param sy The delta of the y-coordinate of the pointer.
      */
     virtual void notify_pointer_motion(Pointer *pointer,
                                        uint32_t time,
                                        double sx,
                                        double sy) = 0;
 
+    /**
+     * \brief Notify the observer of an absolute pointer motion event.
+     *
+     * \param pointer Pointer to the Pointer instance.
+     * \param time The time of the event.
+     * \param ndc_x The normalized device x-coordinate of the pointer. (normalized
+     * device coordinates: range 0 to 1)
+     * \param ndc_y The normalized device y-coordinate of the pointer.
+     */
+    virtual void notify_pointer_motion_absolute(Pointer* pointer,
+                                                uint32_t time,
+                                                double ndc_x,
+                                                double ndc_y) = 0;
+                                                
     /**
      * \brief Notify the observer of a pointer button event.
      *

--- a/include/drmpp/output.h
+++ b/include/drmpp/output.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 drmpp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_DRMPP_OUTPUT_H_
+#define INCLUDE_DRMPP_OUTPUT_H_
+
+#include <unordered_map>
+
+extern "C" {
+#include <libliftoff.h>
+}
+
+#include "composition.h"
+#include "device.h"
+
+namespace drmpp {
+
+/**
+ * @brief An output akin to a logical display, it's something (a physical
+ * display, writeback connector, multiple physical displays in clone mode
+ * (currently unimplemented)) that can show a Composition.
+ *
+ * Usually, you create an Output with a CRTC id and a connector id,
+ * in which case it will present composition on the display connected
+ * to the connector you specified.
+ */
+class Output {
+ public:
+  /**
+   * @brief Create an Output object for the given CRTC and connector, and mode.
+   *
+   */
+  explicit Output(Device& device,
+                  uint32_t crtc_id,
+                  uint32_t connector_id,
+                  const drmModeModeInfo& mode)
+      : device_(device),
+        crtc_id_(crtc_id),
+        connector_id_(connector_id),
+        mode_(mode),
+        output_(::liftoff_output_create(device.liftoff_device(), crtc_id),
+                ::liftoff_output_destroy) {}
+
+  virtual ~Output() {
+    if (mode_blob_id_ != 0) {
+      drmModeDestroyPropertyBlob(device_.fd(), mode_blob_id_);
+    }
+  }
+
+  // Disallow copy, copy-assign, move, move-assign
+  Output(const Output&) = delete;
+  Output& operator=(const Output&) = delete;
+  Output(Output&&) = delete;
+  Output& operator=(Output&&) = delete;
+
+  /**
+   * @brief Present the given composition on the output and
+   *        wait for it to be displayed.
+   */
+  virtual bool present(const Composition& composition);
+
+  /**
+   * @brief Get the CRTC ID of the output.
+   */
+  uint32_t crtc_id() const { return crtc_id_; }
+
+  /**
+   * @brief Get the connector ID of the output.
+   */
+  uint32_t connector_id() const { return connector_id_; }
+
+  /**
+   * @brief The current video mode of the output.
+   */
+  const drmModeModeInfo& mode() const { return mode_; }
+
+  /**
+   * @brief The current (precise) refresh rate of the output.
+   */
+  double refreshRate() const {
+    return mode_.clock * 1000.0 / (mode_.htotal * mode_.vtotal);
+  }
+
+  /**
+   * @brief The current width (in pixels) of the output, based on the current
+   * video mode.
+   */
+  uint32_t width() const { return mode_.hdisplay; }
+
+  /**
+   * @brief The current height (in pixels) of the output, based on the current
+   * video mode.
+   */
+  uint32_t height() const { return mode_.vdisplay; }
+
+ private:
+  /// The ids of the "MODE" and "ACTIVE" properties of the CRTC.
+  struct Props {
+    uint32_t mode_id = 0;
+    uint32_t active = 0;
+  };
+
+  Device& device_;
+  const uint32_t crtc_id_;
+  const uint32_t connector_id_;
+  const drmModeModeInfo mode_;
+
+  // The liftoff_output object for this output.
+  std::unique_ptr<struct liftoff_output, decltype(&::liftoff_output_destroy)>
+      output_;
+
+  // True if we already applied our desired mode on the CRTC.
+  bool did_set_mode = false;
+
+  // The id of the property blob that contains the uploaded video mode.
+  uint32_t mode_blob_id_ = 0;
+
+  /**
+   * @brief A vector containing all the liftoff_layers that were created
+   * for this output.
+   *
+   * Every created layer is added to this vector so we can reuse them
+   * for the next frame.
+   */
+  std::vector<
+      std::unique_ptr<struct liftoff_layer, decltype(&::liftoff_layer_destroy)>>
+      layers_;
+
+  /// TODO: Invalidate the cache sometimes.
+  std::unordered_map<Buffer*, std::unique_ptr<Framebuffer>> fb_cache_;
+
+  std::optional<Props> crtc_props_;
+
+  /**
+   * @brief Add the given buffer as a framebuffer to the KMS device,
+   *        and add it to an internal cache.
+   *
+   * If the buffer was already added before, the framebuffer ID is returned.
+   *
+   * @returns The framebuffer ID, suitable as an argument to
+   * liftoff_layer_set_property(..., "FB_ID", ...) of the added buffer, or 0
+   * if the buffer could not be added.
+   */
+  uint32_t addFramebuffer(Buffer* buffer);
+
+  /**
+   * @brief Resolve some basic property ids, such as the MODE_ID and ACTIVE
+   * CRTC properties.
+   */
+  static std::optional<Props> resolveProps(int fd, uint32_t crtc_id);
+
+  /**
+   * @brief Apply the desired video mode (stored in member mode_)
+   * on the atomic request.
+   */
+  bool applyMode(drmModeAtomicReq* req);
+};
+
+}  // namespace drmpp
+
+#endif  // INCLUDE_DRMPP_OUTPUT_H_

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -14,34 +14,24 @@
  * limitations under the License.
  */
 
-#ifndef INCLUDE_DRMPP_H_
-#define INCLUDE_DRMPP_H_
+#include "buffer.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <cstdio>
 #include <cstring>
 
-#include "config.h"
+void drmpp::Buffer::fill(const uint32_t fourByteColor) {
+  uint32_t offset, stride;
+  std::size_t size;
 
-extern "C" {
-#include <libdisplay-info/info.h>
-#include <libinput.h>
-#include <libliftoff.h>
+  void* buffer = map(offset, stride, size, 0);
+  if (!buffer) {
+    return;
+  }
+
+  // fill the buffer, starting from buffer + offset to buffer + offset + size
+  // with repeating 4-byte color
+  for (std::size_t i = 0; i < size; i += 4) {
+    std::memcpy(static_cast<uint8_t*>(buffer) + offset + i, &fourByteColor, 4);
+  }
+
+  unmap(buffer);
 }
-
-#include "buffer.h"
-#include "composition.h"
-#include "cursor/xcursor.h"
-#include "device.h"
-#include "output.h"
-
-#include "info/info.h"
-#include "input/keyboard.h"
-#include "input/pointer.h"
-#include "input/seat.h"
-#include "input/touch.h"
-#include "logging/logging.h"
-#include "plane/plane.h"
-
-#endif  // INCLUDE_DRMPP_H_

--- a/src/device.cc
+++ b/src/device.cc
@@ -31,10 +31,10 @@ namespace drmpp {
 class DumbBuffer : public Buffer {
  public:
   explicit DumbBuffer(Device& drm_device,
-                      uint32_t width,
-                      uint32_t height,
-                      uint32_t format,
-                      uint64_t modifier,
+                      const uint32_t width,
+                      const uint32_t height,
+                      const uint32_t format,
+                      const uint64_t modifier,
                       const Plane& plane)
       : Buffer(width, height, format, modifier, plane),
         drm_device_(drm_device) {}
@@ -179,7 +179,9 @@ void GbmBuffer::unmap(void* memory) {
 
 class DrmFramebufferImpl : public Framebuffer {
  public:
-  explicit DrmFramebufferImpl(Device& device, Buffer& buffer, uint32_t fb_id)
+  explicit DrmFramebufferImpl(Device& device,
+                              Buffer& buffer,
+                              const uint32_t fb_id)
       : Framebuffer(buffer, fb_id), device_(device) {}
 
   ~DrmFramebufferImpl() override { ::drmModeRmFB(device_.fd(), fb_id()); }
@@ -197,11 +199,11 @@ Device::~Device() {
   }
 }
 
-std::unique_ptr<Buffer> Device::createDumbBuffer(uint32_t width,
-                                                 uint32_t height,
-                                                 uint32_t bpp,
-                                                 uint32_t format,
-                                                 uint64_t modifier) {
+std::unique_ptr<Buffer> Device::createDumbBuffer(const uint32_t width,
+                                                 const uint32_t height,
+                                                 const uint32_t bpp,
+                                                 const uint32_t format,
+                                                 const uint64_t modifier) {
   drm_mode_create_dumb create = {
       .height = height,
       .width = width,
@@ -228,11 +230,11 @@ std::unique_ptr<Buffer> Device::createDumbBuffer(uint32_t width,
 }
 
 std::unique_ptr<Buffer> Device::createGbmBuffer(
-    uint32_t width,
-    uint32_t height,
-    uint32_t format,
+    const uint32_t width,
+    const uint32_t height,
+    const uint32_t format,
     const std::vector<uint64_t>& allowed_modifiers,
-    uint32_t usage) {
+    const uint32_t usage) {
   struct gbm_bo* bo;
   if (allowed_modifiers.empty()) {
     bo = ::gbm_bo_create(gbm_device_.get(), width, height, format, usage);
@@ -330,7 +332,7 @@ std::unique_ptr<Output> Device::openFirstConnectedOutput() {
   return std::make_unique<Output>(*this, crtc_id, conn_id, mode);
 }
 
-std::optional<uint64_t> Device::try_get_cap(uint64_t cap) const {
+std::optional<uint64_t> Device::try_get_cap(const uint64_t cap) const {
   uint64_t value;
   if (drmGetCap(fd_, cap, &value) == 0) {
     return value;

--- a/src/device.cc
+++ b/src/device.cc
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2024 The drmpp Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <map>
+
+#include <drm_fourcc.h>
+#include <gbm.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include "device.h"
+#include "plane/plane.h"
+
+namespace drmpp {
+
+class DumbBuffer : public Buffer {
+ public:
+  explicit DumbBuffer(Device& drm_device,
+                      uint32_t width,
+                      uint32_t height,
+                      uint32_t format,
+                      uint64_t modifier,
+                      const Plane& plane)
+      : Buffer(width, height, format, modifier, plane),
+        drm_device_(drm_device) {}
+
+  // Destructor removes dumb buffer.
+  ~DumbBuffer() override;
+
+  void* map(uint32_t& offset,
+            uint32_t& stride,
+            std::size_t& size,
+            std::size_t plane_index) override;
+
+  void unmap(void* memory) override;
+
+ private:
+  Device& drm_device_;
+  std::map<void*, std::size_t> mappings_;
+};
+
+DumbBuffer::~DumbBuffer() {
+  drm_mode_destroy_dumb destroy = {.handle = planes_[0].gem_handle};
+  ::drmIoctl(drm_device_.fd(), DRM_IOCTL_MODE_DESTROY_DUMB, &destroy);
+}
+
+void* DumbBuffer::map(uint32_t& offset,
+                      uint32_t& stride,
+                      std::size_t& size,
+                      std::size_t plane_index) {
+  if (plane_index >= planes_.size()) {
+    return nullptr;
+  }
+
+  const Plane& plane = planes_[plane_index];
+
+  drm_mode_map_dumb map = {.handle = plane.gem_handle};
+  if (::drmIoctl(drm_device_.fd(), DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
+    return nullptr;
+  }
+
+  void* result = ::mmap(nullptr, plane.size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                        drm_device_.fd(), static_cast<off_t>(map.offset));
+  if (result == MAP_FAILED) {
+    return nullptr;
+  }
+
+  mappings_[result] = plane.size;
+
+  offset = plane.offset;
+  stride = plane.stride;
+  size = plane.size;
+  return result;
+}
+
+void DumbBuffer::unmap(void* memory) {
+  auto it = mappings_.find(memory);
+  if (it == mappings_.end()) {
+    return;
+  }
+
+  ::munmap(memory, it->second);
+
+  mappings_.erase(it);
+}
+
+class GbmBuffer : public Buffer {
+ public:
+  explicit GbmBuffer(
+      Device& drm_device,
+      std::unique_ptr<struct gbm_bo, decltype(&::gbm_bo_destroy)> bo)
+      : Buffer(::gbm_bo_get_width(bo.get()),
+               ::gbm_bo_get_height(bo.get()),
+               ::gbm_bo_get_format(bo.get()),
+               ::gbm_bo_get_modifier(bo.get())),
+        drm_device_(drm_device),
+        bo_(std::move(bo)) {
+    add_planes();
+  }
+
+  void* map(uint32_t& offset,
+            uint32_t& stride,
+            std::size_t& size,
+            std::size_t plane_index) override;
+
+  void unmap(void* memory) override;
+
+ private:
+  void add_planes();
+
+  Device& drm_device_;
+  std::unique_ptr<struct gbm_bo, decltype(&::gbm_bo_destroy)> bo_;
+  std::map<void*, void*> mappings_;
+};
+
+void GbmBuffer::add_planes() {
+  struct gbm_bo* bo = bo_.get();
+
+  int n_planes = ::gbm_bo_get_plane_count(bo);
+  planes_.reserve(n_planes);
+
+  for (int i = 0; i < n_planes; i++) {
+    /// TODO: This can fail
+    gbm_bo_handle handle = ::gbm_bo_get_handle_for_plane(bo, i);
+    uint32_t offset = ::gbm_bo_get_offset(bo, i);
+    uint32_t stride = ::gbm_bo_get_stride_for_plane(bo, i);
+    std::size_t size = offset + stride * ::gbm_bo_get_height(bo);
+
+    planes_.push_back(Buffer::Plane{
+        .gem_handle = handle.u32,
+        .offset = offset,
+        .stride = stride,
+        .size = size,
+    });
+  }
+}
+
+void* GbmBuffer::map(uint32_t& offset,
+                     uint32_t& stride,
+                     std::size_t& size,
+                     std::size_t plane_index) {
+  void* userdata = nullptr;
+
+  void* memory = ::gbm_bo_map(bo_.get(), 0, 0, width(), height(),
+                              GBM_BO_TRANSFER_READ_WRITE, &stride, &userdata);
+  if (!memory) {
+    return nullptr;
+  }
+
+  mappings_[memory] = userdata;
+  return memory;
+}
+
+void GbmBuffer::unmap(void* memory) {
+  auto it = mappings_.find(memory);
+  if (it == mappings_.end()) {
+    return;
+  }
+
+  ::gbm_bo_unmap(bo_.get(), it->second);
+
+  mappings_.erase(it);
+}
+
+class DrmFramebufferImpl : public Framebuffer {
+ public:
+  explicit DrmFramebufferImpl(Device& device, Buffer& buffer, uint32_t fb_id)
+      : Framebuffer(buffer, fb_id), device_(device) {}
+
+  ~DrmFramebufferImpl() override { ::drmModeRmFB(device_.fd(), fb_id()); }
+
+ private:
+  Device& device_;
+};
+
+Device::~Device() {
+  // Destroy the gbm_device before closing the fd.
+  gbm_device_ = {};
+
+  if (fd_ >= 0) {
+    ::close(fd_);
+  }
+}
+
+std::unique_ptr<Buffer> Device::createDumbBuffer(uint32_t width,
+                                                 uint32_t height,
+                                                 uint32_t bpp,
+                                                 uint32_t format,
+                                                 uint64_t modifier) {
+  drm_mode_create_dumb create = {
+      .height = height,
+      .width = width,
+      .bpp = bpp,
+      .flags = 0,
+  };
+
+  int ret = ::drmIoctl(fd_, DRM_IOCTL_MODE_CREATE_DUMB, &create);
+  if (ret < 0) {
+    return nullptr;
+  }
+
+  Buffer::Plane plane = {
+      .gem_handle = create.handle,
+      .offset = 0,
+      .stride = create.pitch,
+      .size = create.size,
+  };
+
+  auto bo = std::make_unique<DumbBuffer>(*this, width, height, format, modifier,
+                                         plane);
+
+  return bo;
+}
+
+std::unique_ptr<Buffer> Device::createGbmBuffer(
+    uint32_t width,
+    uint32_t height,
+    uint32_t format,
+    const std::vector<uint64_t>& allowed_modifiers,
+    uint32_t usage) {
+  struct gbm_bo* bo;
+  if (allowed_modifiers.empty()) {
+    bo = ::gbm_bo_create(gbm_device_.get(), width, height, format, usage);
+  } else {
+    bo = ::gbm_bo_create_with_modifiers2(gbm_device_.get(), width, height,
+                                         format, allowed_modifiers.data(),
+                                         allowed_modifiers.size(), usage);
+  }
+
+  if (bo == nullptr) {
+    return nullptr;
+  }
+
+  // Destroy the BO with gbm_bo_gestroy.
+  auto bo_ptr = std::unique_ptr<gbm_bo, decltype(&::gbm_bo_destroy)>(
+      bo, ::gbm_bo_destroy);
+
+  auto drm_bo = std::make_unique<GbmBuffer>(*this, std::move(bo_ptr));
+
+  return drm_bo;
+}
+
+std::unique_ptr<Framebuffer> Device::addFramebuffer(Buffer& buffer) {
+  uint32_t handles[4] = {0};
+  uint32_t strides[4] = {0};
+  uint32_t offsets[4] = {0};
+  uint64_t modifiers[4] = {0};
+  uint32_t fb_id;
+
+  uint64_t modifier = buffer.modifier();
+  bool have_modifier = modifier != DRM_FORMAT_MOD_INVALID;
+
+  uint32_t flags = 0;
+  if (have_modifier) {
+    flags |= DRM_MODE_FB_MODIFIERS;
+  }
+
+  std::size_t index = 0;
+  for (const auto& plane : buffer) {
+    handles[index] = plane.gem_handle;
+    strides[index] = plane.stride;
+    offsets[index] = plane.offset;
+
+    // The DRM_IOCTL_MODE_ADDFB2 ioctl expects the modifiers to be 0
+    // (not DRM_FORMAT_MOD_INVALID) if  the DRM_MODE_FB_MODIFIERS flag
+    // is not set.
+    modifiers[index] = have_modifier ? modifier : 0;
+    index++;
+  }
+
+  int ret = ::drmModeAddFB2WithModifiers(fd_, buffer.width(), buffer.height(),
+                                         buffer.format(), handles, strides,
+                                         offsets, modifiers, &fb_id, flags);
+
+  if (ret < 0) {
+    LOG_ERROR("Failed to add framebuffer. drmModeAddFB2WithModifiers: {}",
+              std::strerror(-ret));
+    return nullptr;
+  }
+
+  auto fb = std::make_unique<DrmFramebufferImpl>(*this, buffer, fb_id);
+  return fb;
+}
+
+std::unique_ptr<Output> Device::openFirstConnectedOutput() {
+  auto res = std::unique_ptr<drmModeRes, decltype(&::drmModeFreeResources)>(
+      ::drmModeGetResources(fd_), ::drmModeFreeResources);
+  if (!res) {
+    /// TODO: Error message
+    return nullptr;
+  }
+
+  const auto connector = drmpp::plane::Common::pick_connector(fd_, res.get());
+  if (connector == nullptr) {
+    /// TODO: Error message
+    return nullptr;
+  }
+
+  const auto conn_id = connector->connector_id;
+
+  const auto crtc = drmpp::plane::Common::pick_crtc(fd_, res.get(), connector);
+  if (crtc == nullptr || !crtc->mode_valid) {
+    /// TODO: Error message
+    drmModeFreeConnector(connector);
+    return nullptr;
+  }
+
+  const auto crtc_id = crtc->crtc_id;
+
+  auto mode = crtc->mode;
+
+  drmModeFreeConnector(connector);
+  drmModeFreeCrtc(crtc);
+
+  return std::make_unique<Output>(*this, crtc_id, conn_id, mode);
+}
+
+std::optional<uint64_t> Device::try_get_cap(uint64_t cap) const {
+  uint64_t value;
+  if (drmGetCap(fd_, cap, &value) == 0) {
+    return value;
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace drmpp

--- a/src/info/info.cc
+++ b/src/info/info.cc
@@ -122,7 +122,9 @@ rapidjson::Value DrmInfo::driver_info(
       {"ATOMIC", DRM_CLIENT_CAP_ATOMIC},
       {"ASPECT_RATIO", DRM_CLIENT_CAP_ASPECT_RATIO},
       {"WRITEBACK_CONNECTORS", DRM_CLIENT_CAP_WRITEBACK_CONNECTORS},
+#ifdef DRM_CLIENT_CAP_CURSOR_PLANE_HOTSPOT
       {"CURSOR_PLANE_HOTSPOT", DRM_CLIENT_CAP_CURSOR_PLANE_HOTSPOT},
+#endif
   };
 
   // A map to store the general capabilities (name to DRM_CAP constant)
@@ -141,7 +143,9 @@ rapidjson::Value DrmInfo::driver_info(
       {"CRTC_IN_VBLANK_EVENT", DRM_CAP_CRTC_IN_VBLANK_EVENT},
       {"SYNCOBJ", DRM_CAP_SYNCOBJ},
       {"SYNCOBJ_TIMELINE", DRM_CAP_SYNCOBJ_TIMELINE},
+#ifdef DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP
       {"ATOMIC_ASYNC_PAGE_FLIP", DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP},
+#endif
   };
 
   drmVersion* ver = drm->GetVersion(fd);

--- a/src/input/pointer.cc
+++ b/src/input/pointer.cc
@@ -161,11 +161,14 @@ namespace drmpp::input {
     }
   }
 
-  void Pointer::handle_pointer_motion_absolute_event(libinput_event_pointer *ev) {
-    std::scoped_lock lock(observers_mutex_);
-    // TODO needs to reference surface size
-    LOG_INFO("motion absolute: x: {}, y: {}",
-             libinput_event_pointer_get_absolute_x_transformed(ev, 1024),
-             libinput_event_pointer_get_absolute_y_transformed(ev, 768));
+void Pointer::handle_pointer_motion_absolute_event(libinput_event_pointer* ev) {
+  std::scoped_lock lock(observers_mutex_);
+
+  const auto ndc_x = libinput_event_pointer_get_absolute_x_transformed(ev, 1);
+  const auto ndc_y = libinput_event_pointer_get_absolute_y_transformed(ev, 1);
+  for (const auto observer : observers_) {
+    observer->notify_pointer_motion_absolute(this, 0, ndc_x, ndc_y);
   }
-} // namespace drmpp::input
+}
+
+}  // namespace drmpp::input

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,9 @@ drmpp_sources = [
     'drm/libdrm.cc',
     'gbm/libgbm.cc',
     'utils/virtual_terminal.cc',
+    'buffer.cc',
+    'device.cc',
+    'output.cc',
 ]
 
 drmpp_lib = library('drmpp',

--- a/src/output.cc
+++ b/src/output.cc
@@ -191,7 +191,8 @@ uint32_t Output::addFramebuffer(Buffer* buffer) {
   return fb_cache_[buffer]->fb_id();
 }
 
-std::optional<Output::Props> Output::resolveProps(int fd, uint32_t crtc_id) {
+std::optional<Output::Props> Output::resolveProps(const int fd,
+                                                  const uint32_t crtc_id) {
   Props result = {0};
 
   auto crtc_res =

--- a/src/output.cc
+++ b/src/output.cc
@@ -19,6 +19,7 @@
 #include <cstring>
 
 #include "composition.h"
+#include "libliftoff.h"
 #include "logging/logging.h"
 #include "output.h"
 
@@ -148,8 +149,19 @@ bool Output::present(const Composition& composition) {
     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
   }
 
+#ifndef NDEBUG
+  struct liftoff_output_apply_options options = {
+      .timeout_ns = 1000 * 1000 * 1000,  // 1s
+  };
+#else
+  struct liftoff_output_apply_options options = {
+      // 1ms, same as the internal libliftoff default.
+      .timeout_ns = 1 * 1000 * 1000,
+  };
+#endif
+
   /// TODO: Add composition layer.
-  int ok = ::liftoff_output_apply(output_.get(), req.get(), flags, nullptr);
+  int ok = ::liftoff_output_apply(output_.get(), req.get(), flags, &options);
   if (ok < 0) {
     LOG_ERROR("Plane allocation failed. liftoff_output_apply: {}",
               std::strerror(-ok));

--- a/src/output.cc
+++ b/src/output.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2024 The drmpp Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "output.h"
+
+#include <cstring>
+
+#include "composition.h"
+#include "logging/logging.h"
+#include "output.h"
+
+namespace drmpp {
+
+bool Output::present(const Composition& composition) {
+  // For now, we do the stupid thing and recreate all layers every frame.
+  layers_.clear();
+
+  /// TODO: Allocate a composition layer (& buffer), and blit all layers that
+  ///       didn't get a plane into it.
+
+  uint64_t zpos = 0;
+  for (const auto& layer : composition) {
+    auto buffer = layer.buffer;
+    auto src = layer.src;
+    auto dst = layer.dst;
+
+    /// TODO: Cache layers
+    struct liftoff_layer* output_layer = ::liftoff_layer_create(output_.get());
+    if (!output_layer) {
+      LOG_ERROR("Failed to create liftoff layer. liftoff_layer_create: {}",
+                std::strerror(ENOMEM));
+      return false;
+    }
+
+    layers_.emplace_back(output_layer, ::liftoff_layer_destroy);
+
+    uint32_t fb_id = addFramebuffer(buffer.get());
+
+    ::liftoff_layer_set_property(output_layer, "FB_ID", fb_id);
+    ::liftoff_layer_set_property(output_layer, "CRTC_X", dst.x);
+    ::liftoff_layer_set_property(output_layer, "CRTC_Y", dst.y);
+    ::liftoff_layer_set_property(output_layer, "CRTC_W", dst.w);
+    ::liftoff_layer_set_property(output_layer, "CRTC_H", dst.h);
+    ::liftoff_layer_set_property(output_layer, "SRC_X", src.x << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_Y", src.y << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_W", src.w << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_H", src.h << 16);
+    ::liftoff_layer_set_property(output_layer, "zpos", zpos);
+
+    zpos++;
+  }
+
+  if (const auto* pointer = composition.pointerLayer()) {
+    /* Add a layer for the pointer. */
+    struct liftoff_layer* output_layer = ::liftoff_layer_create(output_.get());
+    if (!output_layer) {
+      LOG_ERROR("Failed to create liftoff layer. liftoff_layer_create: {}",
+                std::strerror(ENOMEM));
+      return false;
+    }
+
+    layers_.emplace_back(output_layer, ::liftoff_layer_destroy);
+
+    // This conveniently returns 0 on error, which is the same as
+    // setting liftoff_layer_set_needs_composition().
+    uint32_t fb_id = addFramebuffer(pointer->buffer.get());
+
+    // If the cursor image is partially offscreen, naively scanning out
+    // the cursor at `cursor_x - hot_x` to `cursor_x - hot_x + cursor_width`
+    // would result in presenting the cursor layer at a negative screen
+    // position.
+    //
+    // Instead, we clip the screen and buffer positions in that case.
+    //
+    // These calculations are a bit easier with two coordinate pairs rather
+    // than top left coordinate + w/h.
+    int out_x1 =
+        static_cast<int>(pointer->x) - static_cast<int>(pointer->hot_x);
+    int out_y1 =
+        static_cast<int>(pointer->y) - static_cast<int>(pointer->hot_y);
+    int out_x2 = static_cast<int>(out_x1 + pointer->buffer->width());
+    int out_y2 = static_cast<int>(out_y1 + pointer->buffer->height());
+
+    int src_x1 = 0;
+    int src_y1 = 0;
+    int src_x2 = src_x1 + static_cast<int>(pointer->buffer->width());
+    int src_y2 = src_y1 + static_cast<int>(pointer->buffer->height());
+
+    if (out_x1 < 0) {
+      const auto inset = -out_x1;
+      out_x1 = 0;
+      src_x1 += inset;
+    }
+    if (out_y1 < 0) {
+      const auto inset = -out_y1;
+      out_y1 = 0;
+      src_y1 += inset;
+    }
+    if (out_x2 > static_cast<int>(width())) {
+      const auto inset = out_x2 - static_cast<int>(width());
+      out_x2 = static_cast<int>(width());
+      src_x2 -= inset;
+    }
+    if (out_y2 > static_cast<int>(height())) {
+      const auto inset = out_y2 - static_cast<int>(height());
+      out_y2 = static_cast<int>(height());
+      src_y2 -= inset;
+    }
+
+    ::liftoff_layer_set_property(output_layer, "FB_ID", fb_id);
+    ::liftoff_layer_set_property(output_layer, "CRTC_X", out_x1);
+    ::liftoff_layer_set_property(output_layer, "CRTC_Y", out_y1);
+    ::liftoff_layer_set_property(output_layer, "CRTC_W", out_x2 - out_x1);
+    ::liftoff_layer_set_property(output_layer, "CRTC_H", out_y2 - out_y1);
+    ::liftoff_layer_set_property(output_layer, "SRC_X", src_x1 << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_Y", src_y1 << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_W",
+                                 (src_x2 - src_x1) << 16);
+    ::liftoff_layer_set_property(output_layer, "SRC_H",
+                                 (src_y2 - src_y1) << 16);
+    ::liftoff_layer_set_property(output_layer, "zpos", zpos);
+
+    zpos++;
+  }
+
+  auto req = std::unique_ptr<drmModeAtomicReq, decltype(&::drmModeAtomicFree)>(
+      ::drmModeAtomicAlloc(), ::drmModeAtomicFree);
+  if (!req) {
+    return false;
+  }
+
+  /// TODO: Implement non-blocking commits
+  uint32_t flags = 0;
+  if (!did_set_mode) {
+    flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+  }
+
+  /// TODO: Add composition layer.
+  int ok = ::liftoff_output_apply(output_.get(), req.get(), flags, nullptr);
+  if (ok < 0) {
+    LOG_ERROR("Plane allocation failed. liftoff_output_apply: {}",
+              std::strerror(-ok));
+    return false;
+  }
+
+  /// TODO: Compose layers here if needed.
+  if (!did_set_mode) {
+    bool success = applyMode(req.get());
+    if (!success) {
+      return false;
+    }
+  }
+
+  ok = ::drmModeAtomicCommit(device_.fd(), req.get(), flags, nullptr);
+  if (ok != 0) {
+    LOG_ERROR("Failed to commit atomic request. drmModeAtomicCommit: {}",
+              std::strerror(-ok));
+    return false;
+  }
+
+  did_set_mode = true;
+
+  return true;
+}
+
+uint32_t Output::addFramebuffer(Buffer* buffer) {
+  auto it = fb_cache_.find(buffer);
+  if (it != fb_cache_.end()) {
+    return it->second->fb_id();
+  }
+
+  auto fb = device_.addFramebuffer(*buffer);
+  if (!fb) {
+    return 0;
+  }
+
+  fb_cache_[buffer] = std::move(fb);
+  return fb_cache_[buffer]->fb_id();
+}
+
+std::optional<Output::Props> Output::resolveProps(int fd, uint32_t crtc_id) {
+  Props result = {0};
+
+  auto crtc_res =
+      ::drmModeObjectGetProperties(fd, crtc_id, DRM_MODE_OBJECT_CRTC);
+
+  // find MODE_ID and ACTIVE properties
+  for (uint32_t i = 0;
+       i < crtc_res->count_props && (result.active == 0 || result.mode_id == 0);
+       i++) {
+    auto prop = ::drmModeGetProperty(fd, crtc_res->props[i]);
+    if (!prop) {
+      continue;
+    }
+
+    if (::strcmp(prop->name, "MODE_ID") == 0) {
+      result.mode_id = crtc_res->props[i];
+    } else if (::strcmp(prop->name, "ACTIVE") == 0) {
+      result.active = crtc_res->props[i];
+    }
+
+    ::drmModeFreeProperty(prop);
+  }
+
+  ::drmModeFreeObjectProperties(crtc_res);
+
+  if (result.mode_id == 0 || result.active == 0) {
+    if (result.mode_id == 0 && result.active == 0) {
+      LOG_ERROR("Failed to find MODE_ID and ACTIVE CRTC properties.");
+    } else {
+      LOG_ERROR("Failed to find {} CRTC property.",
+                result.mode_id == 0 ? "MODE_ID" : "ACTIVE");
+    }
+    return std::nullopt;
+  }
+
+  return result;
+}
+
+bool Output::applyMode(drmModeAtomicReq* req) {
+  uint32_t mode_blob_id;
+
+  if (!crtc_props_) {
+    crtc_props_ = resolveProps(device_.fd(), crtc_id_);
+    if (!crtc_props_) {
+      return false;
+    }
+  }
+
+  int ok = ::drmModeCreatePropertyBlob(device_.fd(), &mode_, sizeof(mode_),
+                                       &mode_blob_id);
+  if (ok != 0) {
+    LOG_ERROR("Failed to upload video mode. drmModeCreatePropertyBlob: {}",
+              std::strerror(-ok));
+    return false;
+  }
+
+  int cursor_before = drmModeAtomicGetCursor(req);
+
+  ok = ::drmModeAtomicAddProperty(req, crtc_id_, crtc_props_->mode_id,
+                                  mode_blob_id);
+  if (ok < 0) {
+    LOG_ERROR(
+        "Failed to add MODE_ID property to atomic request. "
+        "drmModeAtomicAddProperty: {}",
+        std::strerror(-ok));
+    drmModeDestroyPropertyBlob(device_.fd(), mode_blob_id);
+    return false;
+  }
+
+  ok = ::drmModeAtomicAddProperty(req, crtc_id_, crtc_props_->active, 1);
+  if (ok < 0) {
+    LOG_ERROR(
+        "Failed to add ACTIVE property to atomic request. "
+        "drmModeAtomicAddProperty: {}",
+        std::strerror(-ok));
+    drmModeAtomicSetCursor(req, cursor_before);
+    drmModeDestroyPropertyBlob(device_.fd(), mode_blob_id);
+    return false;
+  }
+
+  mode_blob_id_ = mode_blob_id;
+  return true;
+}
+
+}  // namespace drmpp

--- a/tools/drm-debug.sh
+++ b/tools/drm-debug.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+# Error if we're not running as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as root" 1>&2
+    exit 1
+fi
+
+# Enable verbose DRM logging.
+echo 0x1FF >/sys/module/drm/parameters/debug
+
+# Clear kernel logs
+dmesg -C
+
+# Continuously echo kernel logs in background
+dmesg -w &
+PID=$!
+
+# Run the program given as arguments
+set +e
+$@
+
+# kill dmesg
+kill $PID
+
+# Disable DRM logging
+echo 0 > /sys/module/drm/parameters/debug


### PR DESCRIPTION
- add drm::Device:
  - basically a wrapper around the raw file-descriptor to an opened /dev/dri/cardX device node
  - owns a gbm_device and liftoff_device created using that same file descriptor
  - can create drm::Buffer objects using GBM and KMS, and upload those as framebuffers
  - can create a drm::Output object for the first connected display

- add drm::Buffer:
  - wrapper around an (unregistered) framebuffer
  - since there's multiple ways to create buffers with KMS, this is an abstract class, concrete implementations are in device.cc
  - knows its own dimensions, format, format modifier, and the GEM handle, offset, stride & size of its planes
  - can be memory-mapped
    - delegates to DRM_IOCTL_MODE_MAP_DUMP & mmap or gbm_bo_map internally
  - can be added as a framebuffer using drm::Device::addFramebuffer

- add drm::Framebuffer:
  - a special drm::Buffer that was registered as a framebuffer to a drm::Device
  - has an fb_id() that can be used as the `FB_ID` for atomic commits

- add drm::Output:
  - a logical display with a fixed video mode
  - == a DRM CRTC, Connector & mode tuple
  - owns the liftoff_layers
  - can be used to present a drm::Composition, which will set properties on the internal liftoff_layers

- add drm::Composition:
  - an assembled frame, consisting of multiple layers with framebuffers
  - can also contain a pointer layer, to show a mouse cursor